### PR TITLE
Add blaise communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Project exclude paths
 /target/
 ./idea
+.idea/**

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -5,6 +5,7 @@ trigger:
     include:
       - main
       - master
+      - staging
   tags:
     include:
       - '*'

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,47 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-pubsub</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.2.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.7</version>
+        </dependency>
+
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>24.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 
     <build>

--- a/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseMessage.java
+++ b/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseMessage.java
@@ -1,0 +1,29 @@
+package no.ssb.survey.surveycommons.blaisecommunication;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlaiseMessage {
+
+    @NonNull
+    private BlaiseMessageType type;
+
+    @NonNull
+    private String ioNumber;
+
+    @NonNull
+    private String password;
+
+    @NonNull
+    private String ioIdNumber;
+
+    @NonNull
+    private Timestamp timestamp;
+
+    @NonNull
+    private String mainSurveyId;
+}

--- a/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseMessageHandler.java
+++ b/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseMessageHandler.java
@@ -1,0 +1,38 @@
+package no.ssb.survey.surveycommons.blaisecommunication;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.pubsub.v1.PubsubMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface BlaiseMessageHandler {
+
+    Logger log = LoggerFactory.getLogger(BlaiseMessageHandler.class);
+
+    default void process(PubsubMessage message) {
+        parseMessage(message.getData().toStringUtf8());
+    }
+
+    default void parseMessage(String message) {
+        ObjectMapper mapper = new ObjectMapper();
+        BlaiseMessage bMessage = null;
+        try {
+            bMessage = mapper.readValue(message, BlaiseMessage.class);
+
+            switch (bMessage.getType()) {
+                case status -> onStatusUpdate(bMessage);
+                case kontaktinformasjon -> onContactUpdate(bMessage);
+                case avtale -> log.error("avtaler status not implemented");
+                default -> log.warn("Hit default case for message: {}", bMessage);
+            }
+
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    void onStatusUpdate(BlaiseMessage message);
+
+    void onContactUpdate(BlaiseMessage message);
+}

--- a/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseMessageType.java
+++ b/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseMessageType.java
@@ -1,0 +1,5 @@
+package no.ssb.survey.surveycommons.blaisecommunication;
+
+public enum BlaiseMessageType {
+    status, kontaktinformasjon, avtale
+}

--- a/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaisePublisher.java
+++ b/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaisePublisher.java
@@ -1,0 +1,73 @@
+package no.ssb.survey.surveycommons.blaisecommunication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class BlaisePublisher {
+
+    private String mainSurveyId;
+
+    private static BlaisePublisher publisher = null;
+
+    private BlaisePublisher() {
+    }
+
+    public static BlaisePublisher getInstance() {
+        if (publisher == null) {
+            publisher = new BlaisePublisher();
+        }
+        return publisher;
+    }
+
+    public void publish(String projectId, String topicId, BlaiseMessage message) throws IOException, ExecutionException, InterruptedException {
+        TopicName topicName = TopicName.of(projectId, topicId);
+
+        Publisher publisher = null;
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            publisher = Publisher.newBuilder(topicName).build();
+
+            BlaiseMessage bMessage = bootstrapMessage(message);
+
+            ByteString data = ByteString.copyFromUtf8(mapper.writeValueAsString(bMessage));
+
+            PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data)
+                    .putAttributes("mainSurveyId", this.mainSurveyId).build();
+
+            ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+            String messageId = messageIdFuture.get();
+            log.info("Published message ID: {}", messageId);
+
+        } finally {
+            if (publisher != null) {
+                publisher.shutdown();
+                publisher.awaitTermination(1, TimeUnit.MINUTES);
+            }
+        }
+
+    }
+
+    private BlaiseMessage bootstrapMessage(BlaiseMessage message) {
+        message.setTimestamp(new Timestamp(System.currentTimeMillis()));
+        message.setMainSurveyId(this.mainSurveyId);
+
+        return message;
+    }
+
+    public void setMainSurveyId(String mainSurveyId) {
+        this.mainSurveyId = mainSurveyId;
+    }
+
+}

--- a/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseSubscriber.java
+++ b/src/main/java/no/ssb/survey/surveycommons/blaisecommunication/BlaiseSubscriber.java
@@ -1,0 +1,40 @@
+package no.ssb.survey.surveycommons.blaisecommunication;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+public class BlaiseSubscriber {
+
+    public static void subscribe(String projectId, String subscriptionId, BlaiseMessageHandler handler) {
+        ProjectSubscriptionName subscriptionName =
+                ProjectSubscriptionName.of(projectId, subscriptionId);
+
+        // Instantiate an asynchronous message receiver.
+        MessageReceiver receiver =
+                (PubsubMessage message, AckReplyConsumer consumer) -> {
+                    // Handle incoming message, then ack the received message.
+                    System.out.println("Id: " + message.getMessageId());
+                    System.out.println("Data: " + message.getData().toStringUtf8());
+                    handler.process(message);
+                    consumer.ack();
+                };
+
+        Subscriber subscriber = null;
+        subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+        // Start the subscriber.
+        subscriber.startAsync().awaitRunning();
+        log.info("Listening for messages on {}:\n", subscriptionName);
+    }
+
+    public static void subscribeAll(String projectId, List<String> subscriptionIds, BlaiseMessageHandler handler) {
+        subscriptionIds.forEach(subscriptionId -> subscribe(projectId, subscriptionId, handler));
+
+    }
+}


### PR DESCRIPTION
This will enable applications to publish and receive messages from google pubsub.

a mainSurveyId and subscriptionId needs to be configured in order to receive and publish messages.

The flow here will be to create a new class that implements the `BlaiseMessageHandler` interface and overrides the `onStatusUpdate` and `onContactUpdate`.

This is merely a POC/MVP.